### PR TITLE
squid:S3027 - String function use should be optimized for single characters

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 Hammock
 =======
 
+This project is no longer actively maintained, the code has been merged into [Swarmic](https://github.com/swarmic)
+
+
 [![Build Status](https://travis-ci.org/johnament/hammock.png)](https://travis-ci.org/johnament/hammock)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/ws.ament.hammock/hammock/badge.png?style=flat)](http://search.maven.org/#search%7Cga%7C1%7Cws.ament.hammock)
 [![Dependency Status](https://www.versioneye.com/user/projects/574cdc006497d90039ac460e/badge.svg?style=flat)](https://www.versioneye.com/user/projects/574cdc006497d90039ac460e)

--- a/core/src/main/java/ws/ament/hammock/core/config/CLIPropertySource.java
+++ b/core/src/main/java/ws/ament/hammock/core/config/CLIPropertySource.java
@@ -76,7 +76,7 @@ public class CLIPropertySource extends BasePropertySource {
             for(String arg:CLIPropertySource.args){
                 if(arg.startsWith("--")){
                     arg = arg.substring(2);
-                    int index = arg.indexOf("=");
+                    int index = arg.indexOf('=');
                     if(index>0){
                         key = arg.substring(0,index).trim();
                         result.put(prefix+key, arg.substring(index+1).trim());


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:S3027 - String function use should be optimized for single characters.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S3027
Please let me know if you have any questions.
George Kankava