### PR TITLE
squid:S1948 - Fields in a Serializable class should either be transient or serializable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 Hammock
 =======
 
+This project is no longer actively maintained, the code has been merged into [Swarmic](https://github.com/swarmic)
+
+
 [![Build Status](https://travis-ci.org/johnament/hammock.png)](https://travis-ci.org/johnament/hammock)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/ws.ament.hammock/hammock/badge.png?style=flat)](http://search.maven.org/#search%7Cga%7C1%7Cws.ament.hammock)
 [![Dependency Status](https://www.versioneye.com/user/projects/574cdc006497d90039ac460e/badge.svg?style=flat)](https://www.versioneye.com/user/projects/574cdc006497d90039ac460e)

--- a/web-spi/src/main/java/ws/ament/hammock/web/spi/ServletDescriptor.java
+++ b/web-spi/src/main/java/ws/ament/hammock/web/spi/ServletDescriptor.java
@@ -30,7 +30,7 @@ public class ServletDescriptor extends AnnotationLiteral<WebServlet> implements 
     private final String[] value;
     private final String[] urlPatterns;
     private final int loadOnStartup;
-    private final WebInitParam[] initParams;
+    private final transient WebInitParam[] initParams;
     private final boolean asyncSupported;
     private final Class<? extends HttpServlet> servletClass;
 


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule
squid:S1948 - Fields in a Serializable class should either be transient or serializable.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:S1948
Please let me know if you have any questions.
George Kankava