### PR TITLE
squid:UselessImportCheck - Useless imports should be removed

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 Hammock
 =======
 
+This project is no longer actively maintained, the code has been merged into [Swarmic](https://github.com/swarmic)
+
+
 [![Build Status](https://travis-ci.org/johnament/hammock.png)](https://travis-ci.org/johnament/hammock)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/ws.ament.hammock/hammock/badge.png?style=flat)](http://search.maven.org/#search%7Cga%7C1%7Cws.ament.hammock)
 [![Dependency Status](https://www.versioneye.com/user/projects/574cdc006497d90039ac460e/badge.svg?style=flat)](https://www.versioneye.com/user/projects/574cdc006497d90039ac460e)

--- a/web-spi/src/main/java/ws/ament/hammock/web/spi/ServletDescriptor.java
+++ b/web-spi/src/main/java/ws/ament/hammock/web/spi/ServletDescriptor.java
@@ -22,7 +22,6 @@ import javax.enterprise.util.AnnotationLiteral;
 import javax.servlet.annotation.WebInitParam;
 import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
-import java.util.Map;
 
 public class ServletDescriptor extends AnnotationLiteral<WebServlet> implements WebServlet{
 


### PR DESCRIPTION
This pull request is focused on resolving occurrence of Sonar rule
squid:UselessImportCheck - Useless imports should be removed.
You can find more information about the issue here:
https://dev.eclipse.org/sonar/rules/show/squid:UselessImportCheck
Please let me know if you have any questions.
George Kankava