### PR TITLE
HealthCheckServlet: set content-type, close jsonb

### DIFF
--- a/util-health/src/main/java/ws/ament/hammock/health/HealthCheckServlet.java
+++ b/util-health/src/main/java/ws/ament/hammock/health/HealthCheckServlet.java
@@ -29,6 +29,8 @@ import javax.servlet.annotation.WebServlet;
 import javax.servlet.http.HttpServlet;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.ws.rs.core.MediaType;
+
 import java.io.IOException;
 
 @WebServlet(urlPatterns = {"${health.servlet.uri}"}, name = "HealthServlet")
@@ -39,6 +41,7 @@ public class HealthCheckServlet extends HttpServlet {
 
     @Override
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
+        resp.setContentType(MediaType.APPLICATION_JSON);
         Jsonb jsonb = JsonbBuilder.newBuilder().build();
         HealthCheckModel healthCheckModel = healthCheckManager.performHealthChecks();
         if (healthCheckModel.getOutcome().equalsIgnoreCase(HealthCheckResponse.State.UP.name())) {


### PR DESCRIPTION
* set `Content-Type` header to support MicroProfile Rest Client making requests to the `/health` endpoint
* close `HealthCheckServlet`'s instance of `Jsonb` to prevent memory leaks