### PR TITLE
How about add more Forked VM when run all tests in build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -726,6 +726,9 @@
                 <plugin>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.20.1</version>
+                    <configuration>
+                    	<forkCount>1.5C</forkCount>
+                    </configuration>
                 </plugin>
             </plugins>
         </pluginManagement>


### PR DESCRIPTION

Maven will run all tests in a single forked VM by default. This can be problematic if there are a lot of tests or some very memory-hungry ones. We can fork more test VM by setting `<fork>1.5C</fork>`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
